### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10764,7 +10764,7 @@ Discover information about the latest creatures from Magic: The Gathering skill 
 
 *Alexa, ask shark week for a fact.*
 
-#SharkWeek returns early this year, Sunday June 26th at 8/7c! Ask Alexa for shark facts, a countdown for when shark week begins, and more!
+# SharkWeek returns early this year, Sunday June 26th at 8/7c! Ask Alexa for shark facts, a countdown for when shark week begins, and more!
 
 ***
 

--- a/skills/B01C9LRW76/README.md
+++ b/skills/B01C9LRW76/README.md
@@ -9,7 +9,7 @@ To use the D.C. Tech Cal skill, try saying...
 
 Read the latest Washington DC tech news and events from www.dctechcal.com.
 Say: "Alexa ask D.C. Tech for news" or "Alexa, ask D.C. Tech for events"
-#dctech
+# dctech
 
 ***
 

--- a/skills/B01HZ9AETK/README.md
+++ b/skills/B01HZ9AETK/README.md
@@ -27,7 +27,7 @@ A webcam which is retrofitted into a regular cap is connected to the Raspberry P
 When the user asks Alexa to describe the scene, the Alexa Skills Kit triggers Amazon Lambda function to fetch the data from the database (DynamoDB). The correct text is the played as an audio on the Alexa device.
 
 
-#Testing instructions
+# Testing instructions
 1. Speak to Amazon Echo - "Alexa start smart cap" (you should hear the response as: "Sure, You can ask me to describe the scene")
 2. Speak to Amazon Echo - "Alexa ask smart cap" -wait- "describe the scene"" (you should hear the response as: "No data received from device in past one minute"). This makes sure that the Alexa skills kit and dynamoDb are working as expected.
 3. Get the userId. Speak to Amazon Echo - "Alexa ask smart cap to get the user info" (you should hear a long code)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
